### PR TITLE
allow params for the Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ Example
 ````coffeescript
 drone = require 'schedule-drone'
 drone.setConfig
-    connectionString: 'mongodb://localhost:27017/scheduled-events'
+    persistence:
+        type: 'mongodb'
+        connectionString: 'mongodb://localhost:27017/scheduled-events'
+        options: {} # Some mongodb driver options here.
 
 scheduler = drone.daemon()
 

--- a/src/Store.coffee
+++ b/src/Store.coffee
@@ -16,8 +16,10 @@ class Store
         unless (_.isObject @options) and
             (_.isString @options.connectionString)
                 throw new util.Error 'Incorrect params'
-        @options.eventsCollection ||= EVENTS_COLLECTION
-        @connection = mongoose.createConnection @options.connectionString
+        @options.eventsCollection ?= EVENTS_COLLECTION
+        @options.options ?= {}
+        @connection = mongoose.createConnection @options.connectionString, \
+                                                @options.options
         @_setupModel()
 
     closeConnection: (callback) ->

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -39,11 +39,12 @@ exports.setConfig = (options) ->
                         user to start polling for events on demand if false,
                         defaults to true
     ###
-    isOptions = true
-    moduleOptions = options
     unless options.persistence?.type? and options.persistence.type is 'mongodb'
         throw new Error 'Only mongodb persistence is supported currently'
-    store = new Store options.persistance
+    store = new Store options.persistence
+
+    isOptions = true
+    moduleOptions = options
 
 exports.daemon = ->
     ###
@@ -54,7 +55,7 @@ exports.daemon = ->
     ###
     unless isOptions
         throw new Error 'Execute #setConfig() first'
-    new PersistentScheduler store, options
+    new PersistentScheduler store, moduleOptions
 
 exports.schedule = (timestamp, event, payload, callback = ->) ->
     ###

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -19,10 +19,18 @@ store = null
 exports.setConfig = (options) ->
     ###
         Set module configuration.
-        @param {Object} options
-        @param {String} options.connectionString - mongodb connection string
-        @param {String} options.eventsCollection - OPTIONAL - name of the
-                            collection where tasks will be stored,
+        @param {Object} options - params to pass to the scheduler drone
+        @param {Object} options.persistence - options for the persistence
+                                              layer of tasks
+        @param {String} options.persistence.type - the type of storage supported
+                                        Currently only 'mongodb' is supported.
+        @param {String} options.persistence.connectionString - specific option
+                                        for mongoose, the connection string.
+        @param {String} options.persistence.options - specific option
+                                        for mongoose, the second options passed
+                                        to the Mongoose connection constructor.
+        @param {String} options.persistence.eventsCollection - OPTIONAL - name
+                            of the collection where tasks will be stored,
                             default value is 'ScheduledEvents'
         @param {Number} options.scheduleInterval - OPTIONAL - interval in ms
                             to poll the database for new scheduled events,
@@ -33,7 +41,9 @@ exports.setConfig = (options) ->
     ###
     isOptions = true
     moduleOptions = options
-    store = new Store options
+    unless options.persistence?.type? and options.persistence.type is 'mongodb'
+        throw new Error 'Only mongodb persistence is supported currently'
+    store = new Store options.persistance
 
 exports.daemon = ->
     ###

--- a/test/ScheduleDroneTest.coffee
+++ b/test/ScheduleDroneTest.coffee
@@ -1,0 +1,43 @@
+assert = (require 'chai').assert
+moment = require 'moment'
+
+drone = require '../src/'
+
+
+describe 'schedule-drone', ->
+    ###
+        This test suite is intended to test the scheduler drone in an end to
+        end fashion, ie. make sure params are correctly parsed, database
+        is correclty setup, tasks are correctly inserted and executed.
+    ###
+
+    it 'should schedule and execute a one-off task', (done) ->
+
+        event = 'test-one-time'
+        payload = data: true
+        date = moment().add('seconds', 2).toDate()
+
+        drone.setConfig
+            persistence:
+                type: 'mongodb'
+                connectionString: 'mongodb://localhost:27017/scheduled-events'
+
+        # Start the daemon that listens to new tasks and runs current ones.
+        scheduler = drone.daemon()
+
+        scheduler.on event, (receivedPayload) ->
+            assert.deepEqual receivedPayload, payload,
+                'should receive the same payload as the one previously sent!'
+
+            # Check the database.
+            scheduler.store.EventModel.find().exec (error, scheduledEvents) ->
+                if error? then return done error
+
+                assert.lengthOf scheduledEvents, 0, 'should have removed the '+
+                                        'task record before triggering the event'
+                done()
+
+        # Trigger the event.
+        scheduler.schedule date, event, payload, (error) ->
+            if error? then return done error
+            assert.ok true, 'has successfully scheduled the event.'

--- a/test/StoreTest.coffee
+++ b/test/StoreTest.coffee
@@ -18,6 +18,19 @@ describe 'Store', ->
             if err? then done err
             dataStore.closeConnection done
 
+    it 'should support the extended connection options, '+
+       'ie. clustering', (done) ->
+        store = new Store
+            connectionString: 'mongodb://localhost:27017/schedule-drone-test'
+            eventsCollection: 'events'
+            options:
+                someOption: true
+        assert.isDefined store?.connection?.options?.someOption,
+            'should pass the options to the constructor'
+        assert.isTrue store.connection.options.someOption,
+            'should set the correct option value to the underlying driver'
+        done()
+
     it 'should expose the correct api', ->
         assert.ok @store.EventModel?,
             'should expose the model object'


### PR DESCRIPTION
We should be able to specify the persistence store and it's own params to constructor of the  schedule drone 
