### PR TITLE
One-time events not being "done" when using PersistentScheduler

### DIFF
--- a/src/PersistentScheduler.coffee
+++ b/src/PersistentScheduler.coffee
@@ -125,8 +125,9 @@ class PersistentScheduler extends Scheduler
                 if err then throw new util.Error err
 
                 todoEvents = unsolvedOneTimeEvents.concat oneTimeEvents
-                for {timestamp, event, payload} in todoEvents
+                for {id, timestamp, event, payload} in todoEvents
                     @schedule timestamp, event, payload
+                    @store.remove  id, () ->
 
 
 # Public api.

--- a/src/Store.coffee
+++ b/src/Store.coffee
@@ -148,6 +148,16 @@ class Store
 
                 return callback null, event.done is true
 
+    remove: (eventId, callback) ->
+        ###
+            Removes a one-time event.
+            @return {Boolean} whether the event was removed or not.
+        ###
+        @EventModel.remove {_id: eventId},
+            (err) ->
+                if err? then return callback err
+                return callback null, true
+
 
 # Public API
 module.exports = Store


### PR DESCRIPTION
Hi.

I have been tinkering with schedule-drone using mongo as persistence layer.
I have found that, when using one-time events with a persistence layer, the events where not being marked as "done" in mongo once processed. In fact, if they are one-time events, maybe they should be completely removed instead of being marked as solved.

I have added a remove method and a call to it in the PersistentScheduler executeOneTimeEvents method. Whether to call remove or call "solve" here could also be a configuration option.

I'm more a javascript guy (no expert in coffeescript) but so far it seems to work. Hope you find it useful and thanks for creating the module!
